### PR TITLE
[Persistence] Bugfixes in session save

### DIFF
--- a/frontend/src/framework/Workbench.ts
+++ b/frontend/src/framework/Workbench.ts
@@ -402,6 +402,7 @@ export class Workbench implements PublishSubscribe<WorkbenchTopicPayloads> {
             }
             this._guiMessageBroker.setState(GuiState.IsSavingSession, false);
             this._guiMessageBroker.setState(GuiState.SaveSessionDialogOpen, false);
+            this._guiMessageBroker.setState(GuiState.EditSessionDialogOpen, false);
             this._guiMessageBroker.setState(GuiState.SessionHasUnsavedChanges, false);
             return;
         }

--- a/frontend/src/framework/internal/WorkbenchSession/WorkbenchSessionPersistenceService.ts
+++ b/frontend/src/framework/internal/WorkbenchSession/WorkbenchSessionPersistenceService.ts
@@ -418,6 +418,10 @@ export class WorkbenchSessionPersistenceService
                     description: metadata.description ?? null,
                     content: objectToJsonString(this._workbenchSession.getContent()),
                 });
+
+                // ! Make sure you remove the localStorage backup BEFORE you store the new session id
+                this.removeFromLocalStorage();
+
                 this._workbenchSession.setId(id);
                 toast.dismiss(toastId);
                 toast.success("Session successfully created and persisted.");

--- a/frontend/src/framework/internal/components/EditSessionDialog/editSessionDialog.tsx
+++ b/frontend/src/framework/internal/components/EditSessionDialog/editSessionDialog.tsx
@@ -1,5 +1,7 @@
 import React from "react";
 
+import { isEqual } from "lodash";
+
 import { GuiState, useGuiState, useGuiValue } from "@framework/GuiMessageBroker";
 import type { WorkbenchSessionMetadata } from "@framework/internal/WorkbenchSession/PrivateWorkbenchSession";
 import { PrivateWorkbenchSessionTopic } from "@framework/internal/WorkbenchSession/PrivateWorkbenchSession";
@@ -10,7 +12,6 @@ import { Dialog } from "@lib/components/Dialog";
 import { Input } from "@lib/components/Input";
 import { Label } from "@lib/components/Label";
 import { usePublishSubscribeTopicValue } from "@lib/utils/PublishSubscribeDelegate";
-import { isEqual } from "lodash";
 
 import { DashboardPreview } from "../DashboardPreview/dashboardPreview";
 
@@ -52,12 +53,6 @@ export function EditSessionDialog(props: EditSessionDialogProps): React.ReactNod
             setInputFeedback((prev) => ({ ...prev, title: undefined }));
         }
 
-        if (description.trim() === "") {
-            setInputFeedback((prev) => ({ ...prev, description: "Description is required." }));
-            return;
-        } else {
-            setInputFeedback((prev) => ({ ...prev, description: undefined }));
-        }
         props.workbench.getWorkbenchSession().updateMetadata({ title, description });
         props.workbench
             .saveCurrentSession()
@@ -112,7 +107,7 @@ export function EditSessionDialog(props: EditSessionDialogProps): React.ReactNod
                             )}
                         </>
                     </Label>
-                    <Label text="Description">
+                    <Label text="Description (optional)">
                         <>
                             <Input
                                 placeholder="Enter session description"

--- a/frontend/src/framework/internal/components/SaveSessionDialog/saveSessionDialog.tsx
+++ b/frontend/src/framework/internal/components/SaveSessionDialog/saveSessionDialog.tsx
@@ -37,12 +37,6 @@ export function SaveSessionDialog(props: SaveSessionDialogProps): React.ReactNod
             setInputFeedback((prev) => ({ ...prev, title: undefined }));
         }
 
-        if (description.trim() === "") {
-            setInputFeedback((prev) => ({ ...prev, description: "Description is required." }));
-            return;
-        } else {
-            setInputFeedback((prev) => ({ ...prev, description: undefined }));
-        }
         props.workbench.getWorkbenchSession().updateMetadata({ title, description });
         props.workbench
             .saveCurrentSession(true)
@@ -101,7 +95,7 @@ export function SaveSessionDialog(props: SaveSessionDialogProps): React.ReactNod
                             )}
                         </>
                     </Label>
-                    <Label text="Description">
+                    <Label text="Description (optional)">
                         <>
                             <Input
                                 placeholder="Enter session description"


### PR DESCRIPTION
* Fixed timing issue that made save/edit modal store an outdated version
* Made description optional in the save/edit form, to be consistent with the session data model
* Made the temp localStorage session state be discarded on first successful session save